### PR TITLE
Dev

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 GROUP=com.liulishuo.okdownload
-VERSION_NAME=1.0.8-SNAPSHOT
+VERSION_NAME=1.0.8
 
 POM_URL=https://github.com/lingochamp/okdownload/
 ISSUE_URL=https://github.com/lingochamp/okdownload/issues/

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -5,9 +5,9 @@ ext {
     targetSdkVersion = 28
     sourceCompatibilityVersion = JavaVersion.VERSION_1_8
     targetCompatibilityVersion = JavaVersion.VERSION_1_8
-    kotlin_version = '1.3.50'
+    kotlin_version = '1.4.0'
     anko_version = '0.10.1'
-    coroutines_version = '1.3.1'
+    coroutines_version = '1.3.9'
     supportLibrariesVersion = '28.0.0'
 
     dep = [

--- a/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/CompatListenerAssist.java
+++ b/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/CompatListenerAssist.java
@@ -133,7 +133,6 @@ public class CompatListenerAssist {
                 handleCanceled(downloadTaskAdapter);
                 break;
             case FILE_BUSY:
-            case SAME_TASK_BUSY:
                 handleWarn(downloadTaskAdapter, cause, realCause);
                 break;
             case COMPLETED:

--- a/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/DownloadTaskAdapter.java
+++ b/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/DownloadTaskAdapter.java
@@ -605,7 +605,7 @@ public class DownloadTaskAdapter implements BaseDownloadTask, BaseDownloadTask.I
             for (Map.Entry<String, String> entry : headerMap.entrySet()) {
                 builder.addHeader(entry.getKey(), entry.getValue());
             }
-//            builder.setAutoCallbackToUIThread(autoCallbackToUIThread);
+            builder.setAutoCallbackToUIThread(autoCallbackToUIThread);
             return builder.build();
         }
     }

--- a/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/DownloadTaskAdapter.java
+++ b/okdownload-filedownloader/src/main/java/com/liulishuo/filedownloader/DownloadTaskAdapter.java
@@ -605,7 +605,7 @@ public class DownloadTaskAdapter implements BaseDownloadTask, BaseDownloadTask.I
             for (Map.Entry<String, String> entry : headerMap.entrySet()) {
                 builder.addHeader(entry.getKey(), entry.getValue());
             }
-            builder.setAutoCallbackToUIThread(autoCallbackToUIThread);
+//            builder.setAutoCallbackToUIThread(autoCallbackToUIThread);
             return builder.build();
         }
     }

--- a/okdownload-filedownloader/src/test/java/com.liulishuo.filedownloader/CompatListenerAssistTest.java
+++ b/okdownload-filedownloader/src/test/java/com.liulishuo.filedownloader/CompatListenerAssistTest.java
@@ -218,10 +218,8 @@ public class CompatListenerAssistTest {
         doNothing().when(compatListenerAssist).onTaskFinish(mockTaskAdapter);
 
         compatListenerAssist.taskEnd(mockTask, EndCause.FILE_BUSY, null);
-        compatListenerAssist.taskEnd(mockTask, EndCause.SAME_TASK_BUSY, null);
 
         verify(compatListenerAssist).handleWarn(mockTaskAdapter, EndCause.FILE_BUSY, null);
-        verify(compatListenerAssist).handleWarn(mockTaskAdapter, EndCause.SAME_TASK_BUSY, null);
         verify(compatListenerAssist, times(2)).onTaskFinish(mockTaskAdapter);
         verify(mockProgressAssist, times(2)).clearProgress();
         verify(mockSpeedCalculator, times(2)).flush();

--- a/okdownload-kotlin-enhance/src/main/kotlin/com.liulishuo.okdownload.kotlin/DownloadResult.kt
+++ b/okdownload-kotlin-enhance/src/main/kotlin/com.liulishuo.okdownload.kotlin/DownloadResult.kt
@@ -23,6 +23,5 @@ import com.liulishuo.okdownload.core.cause.EndCause
  */
 data class DownloadResult(val cause: EndCause) {
     fun becauseOfCompleted(): Boolean = cause == EndCause.COMPLETED
-    fun becauseOfRepeatedTask(): Boolean =
-        cause == EndCause.SAME_TASK_BUSY || cause == EndCause.FILE_BUSY
+    fun becauseOfRepeatedTask(): Boolean = cause == EndCause.FILE_BUSY
 }

--- a/okdownload-kotlin-enhance/src/main/kotlin/com.liulishuo.okdownload.kotlin/listener/DownloadListenerExtension.kt
+++ b/okdownload-kotlin-enhance/src/main/kotlin/com.liulishuo.okdownload.kotlin/listener/DownloadListenerExtension.kt
@@ -21,12 +21,7 @@ import com.liulishuo.okdownload.DownloadTask
 import com.liulishuo.okdownload.core.breakpoint.BreakpointInfo
 import com.liulishuo.okdownload.core.cause.EndCause
 import com.liulishuo.okdownload.core.cause.ResumeFailedCause
-import com.liulishuo.okdownload.core.listener.DownloadListener1
-import com.liulishuo.okdownload.core.listener.DownloadListener2
-import com.liulishuo.okdownload.core.listener.DownloadListener3
-import com.liulishuo.okdownload.core.listener.DownloadListener4
-import com.liulishuo.okdownload.core.listener.DownloadListener4WithSpeed
-import java.lang.Exception
+import com.liulishuo.okdownload.core.listener.*
 
 /**
  * Correspond to [com.liulishuo.okdownload.DownloadListener.taskStart]
@@ -238,7 +233,6 @@ fun DownloadListener.switchToExceptProgressListener(): DownloadListener = when (
         },
         onCompleted = { this.taskEnd(it, EndCause.COMPLETED, null) },
         onCanceled = { this.taskEnd(it, EndCause.CANCELED, null) },
-        onWarn = { this.taskEnd(it, EndCause.SAME_TASK_BUSY, null) },
         onRetry = { task, cause -> this.retry(task, cause) },
         onError = { task, e -> this.taskEnd(task, EndCause.ERROR, e) }
     )

--- a/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadListener3ExtensionTest.kt
+++ b/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadListener3ExtensionTest.kt
@@ -20,21 +20,9 @@ import com.liulishuo.okdownload.DownloadTask
 import com.liulishuo.okdownload.core.cause.EndCause
 import com.liulishuo.okdownload.core.cause.ResumeFailedCause
 import com.liulishuo.okdownload.core.listener.assist.Listener1Assist
-import com.liulishuo.okdownload.kotlin.listener.createListener3
-import com.liulishuo.okdownload.kotlin.listener.onCanceled
-import com.liulishuo.okdownload.kotlin.listener.onCompleted
-import com.liulishuo.okdownload.kotlin.listener.onConnected
-import com.liulishuo.okdownload.kotlin.listener.onError
-import com.liulishuo.okdownload.kotlin.listener.onProgress
-import com.liulishuo.okdownload.kotlin.listener.onRetry
-import com.liulishuo.okdownload.kotlin.listener.onStarted
-import com.liulishuo.okdownload.kotlin.listener.onWarn
-import io.mockk.MockKAnnotations
-import io.mockk.confirmVerified
-import io.mockk.every
+import com.liulishuo.okdownload.kotlin.listener.*
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 
@@ -80,7 +68,6 @@ class DownloadListener3ExtensionTest {
 
         every { mockTerminal.invoke() } returns Unit
 
-        listener3.taskEnd(mockTask, EndCause.SAME_TASK_BUSY, mockException, mockListener1Model)
         listener3.retry(mockTask, resumeFailedCause)
         listener3.connected(mockTask, blockCount, currentOffset, totalLength)
         listener3.taskStart(mockTask, mockListener1Model)
@@ -121,7 +108,6 @@ class DownloadListener3ExtensionTest {
         every { onError.invoke(mockTask, mockException) } returns Unit
         every { onProgress.invoke(mockTask, currentOffset, totalLength) } returns Unit
 
-        listener3.taskEnd(mockTask, EndCause.SAME_TASK_BUSY, mockException, mockListener1Model)
         verify { onWarn.invoke(mockTask) }
         verify { mockTerminal.invoke() }
         confirmVerified(onWarn)

--- a/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadResultTest.kt
+++ b/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadResultTest.kt
@@ -29,10 +29,7 @@ class DownloadResultTest {
 
     @Test
     fun becauseOfRepeatedTask() {
-        var result = DownloadResult(EndCause.SAME_TASK_BUSY)
-        assert(result.becauseOfRepeatedTask())
-
-        result = DownloadResult(EndCause.FILE_BUSY)
+        var result = DownloadResult(EndCause.FILE_BUSY)
         assert(result.becauseOfRepeatedTask())
     }
 }

--- a/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadTaskExtensionTest.kt
+++ b/okdownload-kotlin-enhance/src/test/java/com/liulishuo/okdownload/kotlin/DownloadTaskExtensionTest.kt
@@ -27,25 +27,13 @@ import com.liulishuo.okdownload.core.dispatcher.DownloadDispatcher
 import com.liulishuo.okdownload.kotlin.listener.createListener
 import com.liulishuo.okdownload.kotlin.listener.onTaskEnd
 import com.liulishuo.okdownload.kotlin.listener.onTaskStart
-import io.mockk.MockKAnnotations
-import io.mockk.confirmVerified
-import io.mockk.every
+import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.verify
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.lang.Exception
-import java.lang.IllegalStateException
 
 @RunWith(RobolectricTestRunner::class)
 class DownloadTaskExtensionTest {
@@ -211,10 +199,6 @@ class DownloadTaskExtensionTest {
             assert(result.becauseOfRepeatedTask())
         }
 
-        every { mockTask.enqueue(any()) } answers {
-            val listener = it.invocation.args[0] as DownloadListener
-            listener.taskEnd(mockTask, EndCause.SAME_TASK_BUSY, null)
-        }
         runBlocking {
             val result = mockTask.await()
             assert(result.becauseOfRepeatedTask())

--- a/okdownload/src/main/java/com/liulishuo/okdownload/DownloadContext.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/DownloadContext.java
@@ -51,8 +51,7 @@ public class DownloadContext {
 
     private final DownloadTask[] tasks;
     volatile boolean started = false;
-    @Nullable
-    final DownloadContextListener contextListener;
+    @Nullable final DownloadContextListener contextListener;
     private final QueueSet set;
     private Handler uiHandler;
 
@@ -116,8 +115,7 @@ public class DownloadContext {
             Collections.addAll(scheduleTaskList, tasks);
             Collections.sort(scheduleTaskList);
             executeOnSerialExecutor(new Runnable() {
-                @Override
-                public void run() {
+                @Override public void run() {
                     for (DownloadTask task : scheduleTaskList) {
                         if (!isStarted()) {
                             callbackQueueEndOnSerialLoop(task.isAutoCallbackToUIThread());
@@ -149,8 +147,7 @@ public class DownloadContext {
         if (isAutoCallbackToUIThread) {
             if (uiHandler == null) uiHandler = new Handler(Looper.getMainLooper());
             uiHandler.post(new Runnable() {
-                @Override
-                public void run() {
+                @Override public void run() {
                     contextListener.queueEnd(DownloadContext.this);
                 }
             });
@@ -222,6 +219,9 @@ public class DownloadContext {
             if (set.syncBufferIntervalMillis != null) {
                 taskBuilder.setSyncBufferIntervalMillis(set.syncBufferIntervalMillis);
             }
+            if (set.autoCallbackToUIThread != null) {
+                taskBuilder.setAutoCallbackToUIThread(set.autoCallbackToUIThread);
+            }
             if (set.minIntervalMillisCallbackProcess != null) {
                 taskBuilder
                         .setMinIntervalMillisCallbackProcess(set.minIntervalMillisCallbackProcess);
@@ -263,6 +263,7 @@ public class DownloadContext {
         private Integer syncBufferSize;
         private Integer syncBufferIntervalMillis;
 
+        private Boolean autoCallbackToUIThread;
         private Integer minIntervalMillisCallbackProcess;
 
         private Boolean passIfAlreadyCompleted;
@@ -351,6 +352,17 @@ public class DownloadContext {
             return this;
         }
 
+        public boolean isAutoCallbackToUIThread() {
+            return autoCallbackToUIThread == null
+                    ? DownloadTask.Builder.DEFAULT_AUTO_CALLBACK_TO_UI_THREAD
+                    : autoCallbackToUIThread;
+        }
+
+        public QueueSet setAutoCallbackToUIThread(Boolean autoCallbackToUIThread) {
+            this.autoCallbackToUIThread = autoCallbackToUIThread;
+            return this;
+        }
+
         public int getMinIntervalMillisCallbackProcess() {
             return minIntervalMillisCallbackProcess == null
                     ? DownloadTask.Builder.DEFAULT_MIN_INTERVAL_MILLIS_CALLBACK_PROCESS
@@ -390,10 +402,8 @@ public class DownloadContext {
 
     static class QueueAttachListener extends DownloadListener2 {
         private final AtomicInteger remainCount;
-        @NonNull
-        private final DownloadContextListener contextListener;
-        @NonNull
-        private final DownloadContext hostContext;
+        @NonNull private final DownloadContextListener contextListener;
+        @NonNull private final DownloadContext hostContext;
 
         QueueAttachListener(@NonNull DownloadContext context,
                             @NonNull DownloadContextListener contextListener, int taskCount) {
@@ -402,8 +412,7 @@ public class DownloadContext {
             this.hostContext = context;
         }
 
-        @Override
-        public void taskStart(@NonNull DownloadTask task) {
+        @Override public void taskStart(@NonNull DownloadTask task) {
         }
 
         @Override

--- a/okdownload/src/main/java/com/liulishuo/okdownload/DownloadTask.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/DownloadTask.java
@@ -791,6 +791,17 @@ public class DownloadTask extends IdentifiedTask implements Comparable<DownloadT
         }
 
         /**
+         * Set whether callback to UI thread automatically.
+         * default is {@link #DEFAULT_AUTO_CALLBACK_TO_UI_THREAD}
+         *
+         * @param autoCallbackToUIThread whether callback to ui thread automatically.
+         */
+        public Builder setAutoCallbackToUIThread(boolean autoCallbackToUIThread) {
+            this.autoCallbackToUIThread = autoCallbackToUIThread;
+            return this;
+        }
+
+        /**
          * Set the minimum internal milliseconds of progress callbacks.
          * default is {@link #DEFAULT_MIN_INTERVAL_MILLIS_CALLBACK_PROCESS}
          *

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/cause/EndCause.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/cause/EndCause.java
@@ -21,6 +21,5 @@ public enum EndCause {
     ERROR,
     CANCELED,
     FILE_BUSY,
-    SAME_TASK_BUSY,
     PRE_ALLOCATE_FAILED
 }

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/dispatcher/CallbackDispatcher.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/dispatcher/CallbackDispatcher.java
@@ -89,15 +89,13 @@ public class CallbackDispatcher {
     }
 
     public void endTasks(@NonNull final Collection<DownloadTask> completedTaskCollection,
-                         @NonNull final Collection<DownloadTask> sameTaskConflictCollection,
                          @NonNull final Collection<DownloadTask> fileBusyCollection) {
         if (completedTaskCollection.size() == 0) {
             return;
         }
 
         Util.d(TAG, "endTasks completed[" + completedTaskCollection.size()
-                + "] sameTask[" + sameTaskConflictCollection.size()
-                + "] fileBusy[" + fileBusyCollection.size() + "]");
+                + "]" + "] fileBusy[" + fileBusyCollection.size() + "]");
 
         if (completedTaskCollection.size() > 0) {
             final Iterator<DownloadTask> iterator = completedTaskCollection.iterator();
@@ -110,28 +108,17 @@ public class CallbackDispatcher {
             }
         }
 
-//
-//        if (sameTaskConflictCollection.size() > 0) {
-//            final Iterator<DownloadTask> iterator = sameTaskConflictCollection.iterator();
-//            while (iterator.hasNext()) {
-//                final DownloadTask task = iterator.next();
-//                if (!task.isAutoCallbackToUIThread()) {
-//                    task.getListener().taskEnd(task, EndCause.SAME_TASK_BUSY, null);
-//                    iterator.remove();
-//                }
-//            }
-//        }
-//
-//        if (fileBusyCollection.size() > 0) {
-//            final Iterator<DownloadTask> iterator = fileBusyCollection.iterator();
-//            while (iterator.hasNext()) {
-//                final DownloadTask task = iterator.next();
-//                if (!task.isAutoCallbackToUIThread()) {
-//                    task.getListener().taskEnd(task, EndCause.FILE_BUSY, null);
-//                    iterator.remove();
-//                }
-//            }
-//        }
+
+        if (fileBusyCollection.size() > 0) {
+            final Iterator<DownloadTask> iterator = fileBusyCollection.iterator();
+            while (iterator.hasNext()) {
+                final DownloadTask task = iterator.next();
+                if (!task.isAutoCallbackToUIThread()) {
+                    task.getListener().taskEnd(task, EndCause.FILE_BUSY, null);
+                    iterator.remove();
+                }
+            }
+        }
 
         if (completedTaskCollection.size() == 0 ) {
             return;
@@ -141,12 +128,9 @@ public class CallbackDispatcher {
             for (DownloadTask task : completedTaskCollection) {
                 task.getListener().taskEnd(task, EndCause.COMPLETED, null);
             }
-//            for (DownloadTask task : sameTaskConflictCollection) {
-//                task.getListener().taskEnd(task, EndCause.SAME_TASK_BUSY, null);
-//            }
-//            for (DownloadTask task : fileBusyCollection) {
-//                task.getListener().taskEnd(task, EndCause.FILE_BUSY, null);
-//            }
+            for (DownloadTask task : fileBusyCollection) {
+                task.getListener().taskEnd(task, EndCause.FILE_BUSY, null);
+            }
         });
     }
 

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcher.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcher.java
@@ -501,10 +501,10 @@ public class DownloadDispatcher {
         DownloadListener activeListener = call.task.getListener();
         DownloadListener listener = conflictTask.getListener();
         if (listener == activeListener) return;
-        if (listener instanceof DownloadListener1) {
-            ((DownloadListener1) listener).setAlwaysRecoverAssistModelIfNotSet(true);
+        if (activeListener instanceof DownloadListener1) {
+            ((DownloadListener1) activeListener).setAlwaysRecoverAssistModelIfNotSet(true);
         } else if (listener instanceof DownloadListener4) {
-            ((DownloadListener4) listener).setAlwaysRecoverAssistModelIfNotSet(true);
+            ((DownloadListener4) activeListener).setAlwaysRecoverAssistModelIfNotSet(true);
         }
         DownloadListenerBunch newListener = new DownloadListenerBunch.Builder()
                 .append(activeListener)

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/DownloadListener3.java
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/DownloadListener3.java
@@ -49,7 +49,6 @@ public abstract class DownloadListener3 extends DownloadListener1 {
                 error(task, realCause);
                 break;
             case FILE_BUSY:
-            case SAME_TASK_BUSY:
                 warn(task);
                 break;
             default:

--- a/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/DownloadListenerSameTaskBunch.kt
+++ b/okdownload/src/main/java/com/liulishuo/okdownload/core/listener/DownloadListenerSameTaskBunch.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2018 LingoChamp Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.liulishuo.okdownload.core.listener
+
+import android.os.Handler
+import com.liulishuo.okdownload.DownloadListener
+import com.liulishuo.okdownload.DownloadTask
+import com.liulishuo.okdownload.core.breakpoint.BreakpointInfo
+import com.liulishuo.okdownload.core.cause.EndCause
+import com.liulishuo.okdownload.core.cause.ResumeFailedCause
+
+/**
+ * Author: raynor
+ * Date: 2020/12/22 2:55 PM
+ * Description:
+ */
+class DownloadListenerSameTaskBunch(val uiHandler: Handler, val listeners: Array<DownloadListenerWrapper>) : DownloadListener {
+    /**
+     * 包装[DownloadListener] 的代理类，没有任何额外逻辑，只是用来保存 实际[DownloadListener] 回调的线程
+     */
+    class DownloadListenerWrapper(val autoCallbackToUIThread: Boolean, listener: DownloadListener) : DownloadListener by listener
+
+    override fun taskStart(task: DownloadTask) {
+        for (listener in listeners) {
+            listener.taskStart(task)
+        }
+    }
+
+    override fun connectTrialStart(
+        task: DownloadTask,
+        requestHeaderFields: Map<String?, List<String?>?>
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.connectTrialStart(task, requestHeaderFields)
+                }
+            } else {
+                listener.connectTrialStart(task, requestHeaderFields)
+            }
+        }
+    }
+
+    override fun connectTrialEnd(
+        task: DownloadTask, responseCode: Int,
+        responseHeaderFields: Map<String?, List<String?>?>
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.connectTrialEnd(task, responseCode, responseHeaderFields)
+                }
+            } else {
+                listener.connectTrialEnd(task, responseCode, responseHeaderFields)
+
+            }
+        }
+    }
+
+    override fun downloadFromBeginning(
+        task: DownloadTask, info: BreakpointInfo,
+        cause: ResumeFailedCause
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.downloadFromBeginning(task, info, cause)
+                }
+            } else {
+                listener.downloadFromBeginning(task, info, cause)
+            }
+        }
+    }
+
+    override fun downloadFromBreakpoint(task: DownloadTask, info: BreakpointInfo) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.downloadFromBreakpoint(task, info)
+                }
+            } else {
+                listener.downloadFromBreakpoint(task, info)
+            }
+        }
+
+
+    }
+
+    override fun connectStart(
+        task: DownloadTask, blockIndex: Int,
+        requestHeaderFields: Map<String?, List<String?>?>
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.connectStart(task, blockIndex, requestHeaderFields)
+                }
+            } else {
+                listener.connectStart(task, blockIndex, requestHeaderFields)
+            }
+        }
+    }
+
+    override fun connectEnd(
+        task: DownloadTask, blockIndex: Int, responseCode: Int,
+        responseHeaderFields: Map<String?, List<String?>?>
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.connectEnd(task, blockIndex, responseCode, responseHeaderFields)
+                }
+            } else {
+                listener.connectEnd(task, blockIndex, responseCode, responseHeaderFields)
+            }
+        }
+    }
+
+    override fun fetchStart(task: DownloadTask, blockIndex: Int, contentLength: Long) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.fetchStart(task, blockIndex, contentLength)
+                }
+            } else {
+                listener.fetchStart(task, blockIndex, contentLength)
+            }
+        }
+    }
+
+    override fun fetchProgress(task: DownloadTask, blockIndex: Int, increaseBytes: Long) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.fetchProgress(task, blockIndex, increaseBytes)
+                }
+            } else {
+                listener.fetchProgress(task, blockIndex, increaseBytes)
+            }
+        }
+    }
+
+    override fun fetchEnd(task: DownloadTask, blockIndex: Int, contentLength: Long) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.fetchEnd(task, blockIndex, contentLength)
+                }
+            } else {
+                listener.fetchEnd(task, blockIndex, contentLength)
+
+            }
+        }
+    }
+
+    override fun taskEnd(
+        task: DownloadTask, cause: EndCause,
+        realCause: Exception?
+    ) {
+        for (listener in listeners) {
+            if (listener.autoCallbackToUIThread) {
+                uiHandler.post {
+                    listener.taskEnd(task, cause, realCause)
+                }
+            } else {
+                listener.taskEnd(task, cause, realCause)
+            }
+        }
+    }
+
+    fun contain(targetListener: DownloadListener): Boolean {
+        for (listener in listeners) {
+            if (listener === targetListener) return true
+        }
+        return false
+    }
+
+    /**
+     * Get the index of `targetListener`, smaller index, earlier to receive callback.
+     *
+     * @param targetListener used for compare and get it's index on the bunch.
+     * @return `-1` if can't find `targetListener` on the bunch, otherwise the index of
+     * the `targetListener` on the bunch.
+     */
+    fun indexOf(targetListener: DownloadListener): Int {
+        for (index in listeners.indices) {
+            val listener = listeners[index]
+            if (listener === targetListener) return index
+        }
+        return -1
+    }
+
+    fun toBuilder(): Builder {
+        return Builder(listeners.toMutableList())
+
+    }
+
+    class Builder(private val listeners: MutableList<DownloadListenerWrapper> = ArrayList()) {
+
+        fun build(uiHandler: Handler): DownloadListenerSameTaskBunch {
+            return DownloadListenerSameTaskBunch(
+                uiHandler,
+                listeners.toTypedArray()
+            )
+        }
+
+        /**
+         * Append `listener` to the end of bunch listener list. Then the `listener` will
+         * listener the callbacks of the host bunch listener attached.
+         *
+         * @param listener will be appended to the end of bunch listener list. if it's `null`,
+         * it will not be appended.
+         */
+        fun append(listener: DownloadListenerWrapper): Builder {
+            if (!listeners.contains(listener)) {
+                listeners.add(listener)
+            }
+            return this
+        }
+
+        fun remove(listener: DownloadListenerWrapper): Boolean {
+            return listeners.remove(listener)
+        }
+    }
+}

--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/breakpoint/BreakpointStoreOnCacheTest.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/breakpoint/BreakpointStoreOnCacheTest.java
@@ -296,8 +296,6 @@ public class BreakpointStoreOnCacheTest {
         verify(cache, never()).remove(eq(1));
         cache.onTaskEnd(1, EndCause.PRE_ALLOCATE_FAILED, null);
         verify(cache, never()).remove(eq(1));
-        cache.onTaskEnd(1, EndCause.SAME_TASK_BUSY, null);
-        verify(cache, never()).remove(eq(1));
     }
 
     @Test

--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/CallbackDispatcherTest.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/CallbackDispatcherTest.java
@@ -231,11 +231,10 @@ public class CallbackDispatcherTest {
     @Test
     public void endTasks() {
         final Collection<DownloadTask> completedTaskCollection = new ArrayList<>();
-        final Collection<DownloadTask> sameTaskConflictCollection = new ArrayList<>();
         final Collection<DownloadTask> fileBusyCollection = new ArrayList<>();
 
         dispatcher
-                .endTasks(completedTaskCollection, sameTaskConflictCollection, fileBusyCollection);
+                .endTasks(completedTaskCollection, fileBusyCollection);
         verify(handler, never()).post(any(Runnable.class));
 
         final DownloadTask autoUiTask = mock(DownloadTask.class);
@@ -253,27 +252,22 @@ public class CallbackDispatcherTest {
         completedTaskCollection.add(autoUiTask);
         completedTaskCollection.add(nonUiTask);
 
-        sameTaskConflictCollection.add(autoUiTask);
-        sameTaskConflictCollection.add(nonUiTask);
 
         fileBusyCollection.add(autoUiTask);
         fileBusyCollection.add(nonUiTask);
 
         dispatcher
-                .endTasks(completedTaskCollection, sameTaskConflictCollection, fileBusyCollection);
+                .endTasks(completedTaskCollection, fileBusyCollection);
 
         verify(nonUiListener)
                 .taskEnd(eq(nonUiTask), eq(EndCause.COMPLETED), nullable(Exception.class));
-        verify(nonUiListener)
-                .taskEnd(eq(nonUiTask), eq(EndCause.SAME_TASK_BUSY), nullable(Exception.class));
+
         verify(nonUiListener)
                 .taskEnd(eq(nonUiTask), eq(EndCause.FILE_BUSY), nullable(Exception.class));
 
         verify(handler).post(any(Runnable.class));
         verify(autoUiListener)
                 .taskEnd(eq(autoUiTask), eq(EndCause.COMPLETED), nullable(Exception.class));
-        verify(autoUiListener)
-                .taskEnd(eq(autoUiTask), eq(EndCause.SAME_TASK_BUSY), nullable(Exception.class));
         verify(autoUiListener)
                 .taskEnd(eq(autoUiTask), eq(EndCause.FILE_BUSY), nullable(Exception.class));
     }

--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcherTest.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/dispatcher/DownloadDispatcherTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ExecutorService;
 import static com.liulishuo.okdownload.TestUtils.mockOkDownload;
 import static com.liulishuo.okdownload.core.cause.EndCause.CANCELED;
 import static com.liulishuo.okdownload.core.cause.EndCause.FILE_BUSY;
-import static com.liulishuo.okdownload.core.cause.EndCause.SAME_TASK_BUSY;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -143,10 +142,6 @@ public class DownloadDispatcherTest {
         assertThat(readyAsyncCalls).containsOnlyOnce(readyCall);
         assertThat(runningAsyncCalls).containsOnlyOnce(runningAsyncCall);
         assertThat(runningSyncCalls).containsOnlyOnce(runningSyncCall);
-
-        verifyTaskEnd(mockReadyTask, SAME_TASK_BUSY, null);
-        verifyTaskEnd(mockRunningAsyncTask, SAME_TASK_BUSY, null);
-        verifyTaskEnd(mockRunningSyncTask, SAME_TASK_BUSY, null);
 
         final DownloadTask mockFileBusyTask1 = mockTask();
         doReturn(mockReadyTask.getFile()).when(mockFileBusyTask1).getFile();

--- a/okdownload/src/test/java/com/liulishuo/okdownload/core/listener/DownloadListener3Test.java
+++ b/okdownload/src/test/java/com/liulishuo/okdownload/core/listener/DownloadListener3Test.java
@@ -94,7 +94,5 @@ public class DownloadListener3Test {
         listener3.taskEnd(task, EndCause.FILE_BUSY, realCause);
         verify(listener3).warn(eq(task));
 
-        listener3.taskEnd(task, EndCause.SAME_TASK_BUSY, realCause);
-        verify(listener3, times(2)).warn(eq(task));
     }
 }


### PR DESCRIPTION
1. 去掉了 SAME_TASK_BUSY , 这种情况只有一个激活的任务，但保证其他相同任务可以正常接收回调
2. 支持同一个任务的 listeners 在不同线程回调 （见1）